### PR TITLE
feat/prompts into stage

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -53,7 +53,6 @@ export async function POST(request: Request) {
 
   if (!chat) {
     const title = await generateTitleFromUserMessage({ message: userMessage });
-    // TO-DO: Add promptId
     await saveChat({ id, userId: session.user.id, title, promptId: selectedPromptId });
   }
 

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -33,7 +33,8 @@ export async function POST(request: Request) {
     id,
     messages,
     selectedChatModel,
-  }: { id: string; messages: Array<Message>; selectedChatModel: string } =
+    selectedPromptId,
+  }: { id: string; messages: Array<Message>; selectedChatModel: string, selectedPromptId: string } =
     await request.json();
 
   const session = await auth();
@@ -53,7 +54,7 @@ export async function POST(request: Request) {
   if (!chat) {
     const title = await generateTitleFromUserMessage({ message: userMessage });
     // TO-DO: Add promptId
-    await saveChat({ id, userId: session.user.id, title, promptId: null });
+    await saveChat({ id, userId: session.user.id, title, promptId: selectedPromptId });
   }
 
   await saveMessages({

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         <Chat
           id={chat.id}
           initialMessages={convertToUIMessages(messagesFromDb)}
-          promptId={promptIdFromCookie?.value}
+          selectedPromptId={promptIdFromCookie?.value}
           selectedChatModel={DEFAULT_CHAT_MODEL}
           selectedVisibilityType={chat.visibility}
           isReadonly={session?.user?.id !== chat.userId}
@@ -59,7 +59,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         id={chat.id}
         initialMessages={convertToUIMessages(messagesFromDb)}
         selectedChatModel={chatModelFromCookie.value}
-        promptId={promptIdFromCookie?.value}
+        selectedPromptId={promptIdFromCookie?.value}
         selectedVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}
       />

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -10,6 +10,7 @@ export default async function Page() {
 
   const cookieStore = await cookies();
   const modelIdFromCookie = cookieStore.get('chat-model');
+  const promptIdFromCookie = cookieStore.get('prompt-id');
 
   if (!modelIdFromCookie) {
     return (
@@ -19,6 +20,7 @@ export default async function Page() {
           id={id}
           initialMessages={[]}
           selectedChatModel={DEFAULT_CHAT_MODEL}
+          selectedPromptId={promptIdFromCookie?.value}
           selectedVisibilityType="private"
           isReadonly={false}
         />
@@ -34,6 +36,7 @@ export default async function Page() {
         id={id}
         initialMessages={[]}
         selectedChatModel={modelIdFromCookie.value}
+        selectedPromptId={promptIdFromCookie?.value}
         selectedVisibilityType="private"
         isReadonly={false}
       />

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -20,14 +20,16 @@ function PureChatHeader({
   selectedModelId,
   selectedVisibilityType,
   selectedPromptId,
+  selectedPrompt,
   isReadonly,
   onPromptChange,
 }: {
   chatId: string;
-  userId: string;
+  userId: string | null;
   selectedModelId: string;
   selectedVisibilityType: VisibilityType;
-  selectedPromptId: string;
+  selectedPromptId: string | null;
+  selectedPrompt?: Prompt | null;
   isReadonly: boolean;
   onPromptChange?: (promptId: string) => void;
 }) {

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -22,14 +22,14 @@ export function Chat({
   selectedChatModel,
   selectedVisibilityType,
   isReadonly,
-  promptId
+  selectedPromptId
 }: {
   id: string;
   initialMessages: Array<Message>;
   selectedChatModel: string;
   selectedVisibilityType: VisibilityType;
   isReadonly: boolean;
-  promptId?: string | null;
+  selectedPromptId?: string | null;
 }) {
   const { mutate } = useSWRConfig();
 
@@ -73,7 +73,7 @@ export function Chat({
           chatId={id}
           selectedModelId={selectedChatModel}
           selectedVisibilityType={selectedVisibilityType}
-          isReadonly={isReadonly} userId={''} selectedPromptId={''} selectedPrompt={null}        />
+          isReadonly={isReadonly} userId={null} selectedPromptId={null}       />
 
         <Messages
           chatId={id}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -45,7 +45,7 @@ export function Chat({
     reload,
   } = useChat({
     id,
-    body: { id, selectedChatModel: selectedChatModel },
+    body: { id, selectedChatModel: selectedChatModel, selectedPromptId: selectedPromptId },
     initialMessages,
     experimental_throttle: 100,
     sendExtraMessageFields: true,


### PR DESCRIPTION
This pull request includes several changes to add support for handling a `selectedPromptId` in various parts of the chat application. The changes impact multiple files and functions to ensure that the `selectedPromptId` is properly passed and utilized throughout the application.

### Handling `selectedPromptId` in API and Page Components:

* [`app/(chat)/api/chat/route.ts`](diffhunk://#diff-dee1550b5ed5afa23c207445438b6542ca172911418ae471e2e285f01ada6469L36-R37): Added `selectedPromptId` to the request body and updated the `saveChat` function to include `selectedPromptId`. [[1]](diffhunk://#diff-dee1550b5ed5afa23c207445438b6542ca172911418ae471e2e285f01ada6469L36-R37) [[2]](diffhunk://#diff-dee1550b5ed5afa23c207445438b6542ca172911418ae471e2e285f01ada6469L56-R57)
* `app/(chat)/chat/[id]/page.tsx`: Updated the `Chat` component to use `selectedPromptId` instead of `promptId`. ([app/(chat)/chat/[id]/page.tsxL46-R46](diffhunk://#diff-febd1062898f083f38daa92c2b8408785a87424badf561fb7ee14e6ed8e4e063L46-R46), [app/(chat)/chat/[id]/page.tsxL62-R62](diffhunk://#diff-febd1062898f083f38daa92c2b8408785a87424badf561fb7ee14e6ed8e4e063L62-R62))
* [`app/(chat)/page.tsx`](diffhunk://#diff-f4633d621567bbfd891aa5c88d7dc9c234ace0f5e61861c74a5c59972ab11035R13): Added retrieval of `prompt-id` from cookies and passed `selectedPromptId` to the `Chat` component. [[1]](diffhunk://#diff-f4633d621567bbfd891aa5c88d7dc9c234ace0f5e61861c74a5c59972ab11035R13) [[2]](diffhunk://#diff-f4633d621567bbfd891aa5c88d7dc9c234ace0f5e61861c74a5c59972ab11035R23) [[3]](diffhunk://#diff-f4633d621567bbfd891aa5c88d7dc9c234ace0f5e61861c74a5c59972ab11035R39)

### Updating Components to Use `selectedPromptId`:

* [`components/chat-header.tsx`](diffhunk://#diff-1c842058aecb8359df1e768abe367bcdbd2936a2539fb9b6384449621f567039R23-R32): Updated the `PureChatHeader` component to include `selectedPrompt` and made `userId` and `selectedPromptId` optional.
* [`components/chat.tsx`](diffhunk://#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31bL25-R32): Updated the `Chat` component to use `selectedPromptId` instead of `promptId` and passed it in the `useChat` hook. [[1]](diffhunk://#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31bL25-R32) [[2]](diffhunk://#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31bL48-R48) [[3]](diffhunk://#diff-015689ed51facf46aa073450a0660cfa8b56e37b6b94248a56ec66550007f31bL76-R76)

### Enhancing Prompt Selector Functionality:

* [`components/prompt-selector.tsx`](diffhunk://#diff-cfe7cd0ac0f7e64b1ce552cdf6c21dacadfbecc2a9792c215fb3354139978e41L41-L48): Updated the `PromptSelector` component to make `userId` and `selectedPromptId` optional, added functionality to read `prompt-id` from cookies, and automatically select a newly created prompt. [[1]](diffhunk://#diff-cfe7cd0ac0f7e64b1ce552cdf6c21dacadfbecc2a9792c215fb3354139978e41L41-L48) [[2]](diffhunk://#diff-cfe7cd0ac0f7e64b1ce552cdf6c21dacadfbecc2a9792c215fb3354139978e41R69-R75) [[3]](diffhunk://#diff-cfe7cd0ac0f7e64b1ce552cdf6c21dacadfbecc2a9792c215fb3354139978e41L93-R109) [[4]](diffhunk://#diff-cfe7cd0ac0f7e64b1ce552cdf6c21dacadfbecc2a9792c215fb3354139978e41R145-R159)